### PR TITLE
Remove the useless condition in the template

### DIFF
--- a/templates/index.twig
+++ b/templates/index.twig
@@ -15,21 +15,13 @@
         <p>
             Moonrise »
             <b>
-                {% if moonphase.rise == '--' %}
-                    yesterday
-                {% else %}
-                    {{ moonphase.rise }}
-                {% endif %}
+                {{ moonphase.rise }}
             </b>
         </p>
         <p>
             Moonset »
             <b>
-                {% if moonphase.set == '--' %}
-                    tomorrow
-                {% else %}
-                    {{ moonphase.set }}
-                {% endif %}
+                {{ moonphase.set }}
             </b>
         </p>
         <p>Moon sign » <b>{{ moonphase.sign }}</b></p>


### PR DESCRIPTION
Related to https://github.com/witch-please/daily-moon/issues/4

The change we had previously done for that turns out to be useless: "--" is only displayed for an hour from time to time, and showing "tomorrow" instead of "--" is irrelevant since later on the API will indeed display a moonset time that happens on the next day.

So let's remove these conditions and simply keep "--" when that's what the API returns.